### PR TITLE
fix broken xml display

### DIFF
--- a/src/main/bdog/Writer/HttpServer/public/lib/View/Bsoad.coffee
+++ b/src/main/bdog/Writer/HttpServer/public/lib/View/Bsoad.coffee
@@ -88,6 +88,6 @@ define ( require, module, exports ) ->
 
         escapeHtml: ( string ) ->
             string = String( string )
-            return string.replace( "&", "&amp;", "g" ).replace( "<", "&lt;", "g" ).replace( ">", "&gt;", "g" ).replace( '"', "&quot;", "g" )
+            return string.replace( /&/g, "&amp;" ).replace( /</g, "&lt;" ).replace( />/g, "&gt;" ).replace( /"/g, "&quot;" )
 
     module.exports = BsoadView


### PR DESCRIPTION
XML tags were not properly escaped in the browser if the xml had more than 1 line.
The patch fixes this, xml is displayed properly now.
